### PR TITLE
Allow specifying scheme for mirror URL

### DIFF
--- a/templates/mirror.erb
+++ b/templates/mirror.erb
@@ -1,9 +1,17 @@
 <% @release.each do |r| -%>
 # mirror <%= @name %>-<%= r %>
+<% if @mirror.include?('://') -%>
+deb <%= @mirror -%>/<%= @os -%> <%= r -%> <%= @components.join(' ') %>
+<% else -%>
 deb http://<%= @mirror -%>/<%= @os -%> <%= r -%> <%= @components.join(' ') %>
+<% end -%>
 
 <% if @source -%>
+<% if @mirror.include?('://') -%>
+deb <%= @mirror -%>/<%= @os -%> <%= r -%> <%= @components.join(' ') %>
+<% else -%>
 deb http://<%= @mirror -%>/<%= @os -%> <%= r -%> <%= @components.join(' ') %>
+<% end -%>
 <% end -%>
 <% end -%>
 


### PR DESCRIPTION
If the mirror source specified contains a ://, then don't prefix it with
http://
