### PR TITLE
Fix source mirroring syntax

### DIFF
--- a/spec/defines/mirror_spec.rb
+++ b/spec/defines/mirror_spec.rb
@@ -7,7 +7,7 @@ describe 'apt_mirror::mirror' do
       :os         => 'ubuntu',
       :release    => ['precise'],
       :components => ['main', 'contrib', 'non-free'],
-      :source     => 'false',
+      :source     => 'true',
     }
   end
 
@@ -34,6 +34,7 @@ describe 'apt_mirror::mirror' do
 
     it do
       should contain_file("#{fragdir}/fragments/02_#{safe_name}").with_content(/deb http:\/\/#{mirror}/)
+      should contain_file("#{fragdir}/fragments/02_#{safe_name}").with_content(/deb-src http:\/\/#{mirror}/)
     end
 
   end
@@ -61,6 +62,7 @@ describe 'apt_mirror::mirror' do
 
     it do
       should contain_file("#{fragdir}/fragments/02_#{safe_name}").with_content(/deb #{mirror}/)
+      should contain_file("#{fragdir}/fragments/02_#{safe_name}").with_content(/deb-src #{mirror}/)
     end
 
   end

--- a/templates/mirror.erb
+++ b/templates/mirror.erb
@@ -8,9 +8,9 @@ deb http://<%= @mirror -%>/<%= @os -%> <%= r -%> <%= @components.join(' ') %>
 
 <% if @source -%>
 <% if @mirror.include?('://') -%>
-deb <%= @mirror -%>/<%= @os -%> <%= r -%> <%= @components.join(' ') %>
+deb-src <%= @mirror -%>/<%= @os -%> <%= r -%> <%= @components.join(' ') %>
 <% else -%>
-deb http://<%= @mirror -%>/<%= @os -%> <%= r -%> <%= @components.join(' ') %>
+deb-src http://<%= @mirror -%>/<%= @os -%> <%= r -%> <%= @components.join(' ') %>
 <% end -%>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
With source => true, you'd just get two identical mirror lines. To
mirror sources, the line needs to start with "deb-src".
