### PR TITLE
Enforce order between the cron job and mirror file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,9 +122,10 @@ class apt_mirror (
   }
 
   concat { '/etc/apt/mirror.list':
-    owner => 'root',
-    group => 'root',
-    mode  => '0644',
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+    before => Cron['apt-mirror'],
   }
 
   concat::fragment { 'mirror.list header':


### PR DESCRIPTION
If you setup a server using this class just before 4am UTC, its possible
for the cron job to be written out before the mirror list is written.
When this happens, the default mirror list file provided by the
apt-mirror package is used. This ends up mirroring the Ubuntu archive.
This bug was discovered when a newly built node had a full HDD.
Enforcing the ordering should ensure that the mirror list is written
first so that you do not unintentionally mirror any packages.
