### PR TITLE
Provide proxy config and enable cron logging

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -149,13 +149,23 @@ class apt_mirror (
     order   => '01',
   }
 
+  $cron_ensure_real = $enabled ? {
+    false   => absent,
+    default => present,
+  }
+
+  $proxy_url_real = $proxy_url ? {
+    undef   => undef,
+    default => [ "http_proxy=${proxy_url}", "https_proxy=${proxy_url}"],
+  }
+
   cron { 'apt-mirror':
-    ensure  => $enabled ? { false => absent, default => present },
-    user    => 'root',
-    command => '/usr/bin/apt-mirror /etc/apt/mirror.list',
-    minute  => 0,
-    hour    => 4,
-    environment => $proxy_url ? { undef => undef, default => [ "http_proxy=${proxy_url}", "https_proxy=${proxy_url}"] },
+    ensure      => $cron_ensure_real,
+    user        => 'root',
+    command     => '/usr/bin/apt-mirror /etc/apt/mirror.list',
+    minute      => 0,
+    hour        => 4,
+    environment => $proxy_url_real,
   }
 
   create_resources('apt_mirror::mirror', $mirror_list)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -163,7 +163,7 @@ class apt_mirror (
   cron::job { 'apt-mirror':
     ensure      => $cron_ensure_real,
     user        => 'root',
-    command     => "/usr/bin/apt-mirror /etc/apt/mirror.list >> ${var_path}/cron.log 2>&1",
+    command     => "/usr/bin/apt-mirror /etc/apt/mirror.list >> ${base_path}/var/cron.log 2>&1",
     minute      => 0,
     hour        => 4,
     environment => $proxy_url_real,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -163,7 +163,7 @@ class apt_mirror (
   cron::job { 'apt-mirror':
     ensure      => $cron_ensure_real,
     user        => 'root',
-    command     => "/usr/bin/apt-mirror /etc/apt/mirror.list >> ${base_path}/var/cron.log 2>&1",
+    command     => "/usr/bin/apt-mirror /etc/apt/mirror.list >> ${base_path}/var/cron.log 2>> ${base_path}/var/cron.error.log",
     minute      => 0,
     hour        => 4,
     environment => $proxy_url_real,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,6 +103,7 @@
 # == Requires
 #
 # puppetlabs-concat
+# puppet-cron
 #
 # == Examples
 #
@@ -140,7 +141,7 @@ class apt_mirror (
     owner  => 'root',
     group  => 'root',
     mode   => '0644',
-    before => Cron['apt-mirror'],
+    before => Cron::Job['apt-mirror'],
   }
 
   concat::fragment { 'mirror.list header':
@@ -159,13 +160,19 @@ class apt_mirror (
     default => [ "http_proxy=${proxy_url}", "https_proxy=${proxy_url}"],
   }
 
-  cron { 'apt-mirror':
+  cron::job { 'apt-mirror':
     ensure      => $cron_ensure_real,
     user        => 'root',
     command     => '/usr/bin/apt-mirror /etc/apt/mirror.list',
     minute      => 0,
     hour        => 4,
     environment => $proxy_url_real,
+  }
+
+  # remove legacy cron job
+  # we use now cron::job
+  cron { 'apt-mirror':
+    ensure => absent,
   }
 
   create_resources('apt_mirror::mirror', $mirror_list)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -163,7 +163,7 @@ class apt_mirror (
   cron::job { 'apt-mirror':
     ensure      => $cron_ensure_real,
     user        => 'root',
-    command     => '/usr/bin/apt-mirror /etc/apt/mirror.list',
+    command     => "/usr/bin/apt-mirror /etc/apt/mirror.list >> ${var_path}/cron.log 2>&1",
     minute      => 0,
     hour        => 4,
     environment => $proxy_url_real,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,6 +94,12 @@
 #
 # Default: false
 #
+# [*proxy_url*]
+#
+# Enable apt-mirror to mirror behind a proxy.
+#
+# Default: no proxy
+#
 # == Requires
 #
 # puppetlabs-concat
@@ -122,7 +128,8 @@ class apt_mirror (
   $wget_auth_no_challenge    = false,
   $wget_no_check_certificate = false,
   $wget_unlink               = false,
-  $mirror_list               = {}
+  $mirror_list               = {},
+  $proxy_url                 = undef,
 ) {
 
   package { 'apt-mirror':
@@ -148,6 +155,7 @@ class apt_mirror (
     command => '/usr/bin/apt-mirror /etc/apt/mirror.list',
     minute  => 0,
     hour    => 4,
+    environment => $proxy_url ? { undef => undef, default => [ "http_proxy=${proxy_url}", "https_proxy=${proxy_url}"] },
   }
 
   create_resources('apt_mirror::mirror', $mirror_list)


### PR DESCRIPTION
Hi,
I needed to setup a proxy to have internet access on my mirror, so I added the proxy param.
To support deletion of that proxy setting, I switched to https://github.com/voxpupuli/puppet-cron.
Now I added logging.