### PR TITLE
Cron params

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -149,13 +149,23 @@ class apt_mirror (
     order   => '01',
   }
 
+  $cron_ensure_real = $enabled ? {
+    false   => absent,
+    default => present,
+  }
+
+  $proxy_url_real = $proxy_url ? {
+    undef   => undef,
+    default => [ "http_proxy=${proxy_url}", "https_proxy=${proxy_url}"],
+  }
+
   cron { 'apt-mirror':
-    ensure  => $enabled ? { false => absent, default => present },
-    user    => 'root',
-    command => '/usr/bin/apt-mirror /etc/apt/mirror.list',
-    minute  => 0,
-    hour    => 4,
-    environment => $proxy_url ? { undef => undef, default => [ "http_proxy=${proxy_url}", "https_proxy=${proxy_url}"] },
+    ensure      => $cron_ensure_real,
+    user        => 'root',
+    command     => '/usr/bin/apt-mirror /etc/apt/mirror.list',
+    minute      => 0,
+    hour        => 4,
+    environment => $proxy_url_real,
   }
 
   create_resources('apt_mirror::mirror', $mirror_list)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -163,7 +163,7 @@ class apt_mirror (
   cron::job { 'apt-mirror':
     ensure      => $cron_ensure_real,
     user        => 'root',
-    command     => "/usr/bin/apt-mirror /etc/apt/mirror.list >> ${var_path}/cron.log 2>&1",
+    command     => "/usr/bin/apt-mirror /etc/apt/mirror.list >> ${base_path}/var/cron.log 2>&1",
     minute      => 0,
     hour        => 4,
     environment => $proxy_url_real,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -100,6 +100,63 @@
 #
 # Default: no proxy
 #
+# [*cron_user*]
+#
+# User to run regular mirror job.
+#
+# Default: root
+#
+# [*cron_command*]
+#
+# Command line to use for regular mirror job.
+# Helpful, if you need to configure monitoring or logging.
+# E.g.: To monitor job with check_mk, set:
+#   cron_command => '/usr/bin/mk-job my-regular-apt-mirror-job /usr/bin/apt-mirror ...'
+#
+# Default: /usr/bin/apt-mirror /etc/apt/mirror.list >> ${base_path}/var/cron.log 2>> ${base_path}/var/cron.error.log
+#
+# [*cron_minute*]
+#
+# When to run cron job.
+#
+# Default: 0
+#
+# [*cron_hour*]
+#
+# When to run cron job.
+#
+# Default: 4
+#
+# [*cron_date*]
+#
+# When to run cron job.
+#
+# Default: *
+#
+# [*cron_month*]
+#
+# When to run cron job.
+#
+# Default: *
+#
+# [*cron_weekday*]
+#
+# When to run cron job.
+#
+# Default: *
+#
+# [*cron_special*]
+#
+# When to run cron job, see https://github.com/voxpupuli/puppet-cron/blob/master/types/special.pp
+#
+# Default: undef
+#
+# [*cron_description*]
+#
+# Optional description.
+#
+# Default: undef
+#
 # == Requires
 #
 # puppetlabs-concat
@@ -131,6 +188,15 @@ class apt_mirror (
   $wget_unlink               = false,
   $mirror_list               = {},
   $proxy_url                 = undef,
+  $cron_user                 = 'root',
+  $cron_command              = "/usr/bin/apt-mirror /etc/apt/mirror.list >> ${base_path}/var/cron.log 2>> ${base_path}/var/cron.error.log",
+  $cron_minute               = 0,
+  $cron_hour                 = 4,
+  $cron_date                 = '*',
+  $cron_month                = '*',
+  $cron_weekday              = '*',
+  $cron_special              = undef,
+  $cron_description          = undef,
 ) {
 
   package { 'apt-mirror':
@@ -162,10 +228,15 @@ class apt_mirror (
 
   cron::job { 'apt-mirror':
     ensure      => $cron_ensure_real,
-    user        => 'root',
-    command     => "/usr/bin/apt-mirror /etc/apt/mirror.list >> ${base_path}/var/cron.log 2>> ${base_path}/var/cron.error.log",
-    minute      => 0,
-    hour        => 4,
+    user        => $cron_user,
+    command     => $cron_command,
+    minute      => $cron_minute,
+    hour        => $cron_hour,
+    date        => $cron_date,
+    month       => $cron_month,
+    weekday     => $cron_weekday,
+    special     => $cron_special,
+    description => $cron_description,
     environment => $proxy_url_real,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -163,7 +163,7 @@ class apt_mirror (
   cron::job { 'apt-mirror':
     ensure      => $cron_ensure_real,
     user        => 'root',
-    command     => "/usr/bin/apt-mirror /etc/apt/mirror.list >> ${base_path}/var/cron.log 2>&1",
+    command     => "/usr/bin/apt-mirror /etc/apt/mirror.list >> ${base_path}/var/cron.log 2>> ${base_path}/var/cron.error.log",
     minute      => 0,
     hour        => 4,
     environment => $proxy_url_real,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,6 +103,7 @@
 # == Requires
 #
 # puppetlabs-concat
+# puppet-cron
 #
 # == Examples
 #
@@ -140,7 +141,7 @@ class apt_mirror (
     owner  => 'root',
     group  => 'root',
     mode   => '0644',
-    before => Cron['apt-mirror'],
+    before => Cron::Job['apt-mirror'],
   }
 
   concat::fragment { 'mirror.list header':
@@ -159,13 +160,19 @@ class apt_mirror (
     default => [ "http_proxy=${proxy_url}", "https_proxy=${proxy_url}"],
   }
 
-  cron { 'apt-mirror':
+  cron::job { 'apt-mirror':
     ensure      => $cron_ensure_real,
     user        => 'root',
     command     => '/usr/bin/apt-mirror /etc/apt/mirror.list',
     minute      => 0,
     hour        => 4,
     environment => $proxy_url_real,
+  }
+
+  # remove legacy cron job
+  # we use now cron::job
+  cron { 'apt-mirror':
+    ensure => absent,
   }
 
   create_resources('apt_mirror::mirror', $mirror_list)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -163,7 +163,7 @@ class apt_mirror (
   cron::job { 'apt-mirror':
     ensure      => $cron_ensure_real,
     user        => 'root',
-    command     => '/usr/bin/apt-mirror /etc/apt/mirror.list',
+    command     => "/usr/bin/apt-mirror /etc/apt/mirror.list >> ${var_path}/cron.log 2>&1",
     minute      => 0,
     hour        => 4,
     environment => $proxy_url_real,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -94,6 +94,12 @@
 #
 # Default: false
 #
+# [*proxy_url*]
+#
+# Enable apt-mirror to mirror behind a proxy.
+#
+# Default: no proxy
+#
 # == Requires
 #
 # puppetlabs-concat
@@ -122,7 +128,8 @@ class apt_mirror (
   $wget_auth_no_challenge    = false,
   $wget_no_check_certificate = false,
   $wget_unlink               = false,
-  $mirror_list               = {}
+  $mirror_list               = {},
+  $proxy_url                 = undef,
 ) {
 
   package { 'apt-mirror':
@@ -148,6 +155,7 @@ class apt_mirror (
     command => '/usr/bin/apt-mirror /etc/apt/mirror.list',
     minute  => 0,
     hour    => 4,
+    environment => $proxy_url ? { undef => undef, default => [ "http_proxy=${proxy_url}", "https_proxy=${proxy_url}"] },
   }
 
   create_resources('apt_mirror::mirror', $mirror_list)


### PR DESCRIPTION
Add params with default values for cron settings.

This extends pull request https://github.com/jtopjian/puppet-apt_mirror/pull/13.
This resolves issue https://github.com/jtopjian/puppet-apt_mirror/issues/11.